### PR TITLE
updated files for both manual tests 

### DIFF
--- a/test/manual_test_goddard.jl
+++ b/test/manual_test_goddard.jl
@@ -1,11 +1,16 @@
+using CTBase
+using CTProblemLibrary
+using CTDirect
+
+
 # goddard with state constraint - maximize altitude
 prob = Problem(:goddard, :state_constraint)
 ocp = prob.model
 
 # initial guess (constant state and control functions)
-init = [1.01, 0.25, 0.5, 0.4]
+init = [1.01, 0.05, 0.8, 0.1]
 
 #sol = solve(ocp, grid_size=20, print_level=5)
-sol = direct_solve(ocp, (:dummy,), grid_size=20, print_level=5, init=init)
+sol = solve(ocp, (:dummy,), grid_size=100, print_level=5, tol=1e-12, mu_strategy="adaptive", init=init)
 
 plot(sol)

--- a/test/manual_test_integrator.jl
+++ b/test/manual_test_integrator.jl
@@ -1,3 +1,7 @@
+using CTBase
+using CTProblemLibrary
+using CTDirect
+
 # double integrator - energy min
 prob = Problem(:integrator, :dim2, :energy)
 ocp = prob.model
@@ -7,7 +11,7 @@ init = [1., 0.5, 0.3]
 
 # solve
 #sol = solve(ocp, grid_size=10, print_level=5)
-sol = direct_solve(ocp, (:dummy,), grid_size=10, print_level=5, init=init)
+sol = solve(ocp, (:dummy,), grid_size=200, print_level=5, tol=1e-12, mu_strategy="adaptive", init=init)
 
 # plot
 plot(sol)


### PR DESCRIPTION
- using CTBase/ProblemLibrary
- call avec solve() au lieu de solve_direct), options ipopt explicites pour tol et mu_strategy

NB. c'est tres lent compare a bocop3 car on a des derivees en format plein. Il faudra tester le creux 