### PR TITLE
retrieve and plot state, control and mixed constraints with their mul…

### DIFF
--- a/src/solution.jl
+++ b/src/solution.jl
@@ -28,7 +28,11 @@ function _OptimalControlSolution(ocp, ipopt_solution, ctd)
     u = ctinterpolate(T, matrix2vec(U, 1))
     p = ctinterpolate(T[1:end-1], matrix2vec(P, 1))
     cx = ctinterpolate(T, matrix2vec(sol_state_constraints, 1))
+    cu = ctinterpolate(T, matrix2vec(sol_control_constraints, 1))
+    cxu = ctinterpolate(T, matrix2vec(sol_mixed_constraints, 1))
     mcx = ctinterpolate(T, matrix2vec(mult_state_constraints, 1))
+    mcu = ctinterpolate(T, matrix2vec(mult_control_constraints, 1))
+    mcxu = ctinterpolate(T, matrix2vec(mult_mixed_constraints, 1))
 
     # build OptimalControlSolution struct
     sol = OptimalControlSolution()
@@ -47,11 +51,15 @@ function _OptimalControlSolution(ocp, ipopt_solution, ctd)
     sol.message = "no message" 
     sol.success = false #
     # field "infos" in OptimalControlSolution is Dict{Symbol, Any}, for misc data
-    # +++ todo: labels for constraints
     sol.infos[:dim_state_constraints] = ctd.dim_state_constraints    
     sol.infos[:state_constraints] = t -> cx(t)
     sol.infos[:mult_state_constraints] = t -> mcx(t)
-    # +++ add control and mixed constraints
+    sol.infos[:dim_control_constraints] = ctd.dim_control_constraints    
+    sol.infos[:control_constraints] = t -> cu(t)
+    sol.infos[:mult_control_constraints] = t -> mcu(t)
+    sol.infos[:dim_mixed_constraints] = ctd.dim_mixed_constraints    
+    sol.infos[:mixed_constraints] = t -> cxu(t)
+    sol.infos[:mult_mixed_constraints] = t -> mcxu(t)
     # +++ then add box multipliers
 
 

--- a/test/test_goddard.jl
+++ b/test/test_goddard.jl
@@ -25,13 +25,13 @@ end =#
 
 # box constraint formulation
 println("Box constraint formulation")
-println(constraints(ocp))
+#println(constraints(ocp))
 remove_constraint!(ocp, :state_constraint_r)
 remove_constraint!(ocp, :state_constraint_v)
 remove_constraint!(ocp, :control_constraint)
 constraint!(ocp, :state, 1:3, [1,0,0.6], [Inf,0.1,1], :box_state)
 constraint!(ocp, :control, Index(1), 0, 1, :box_control)
-println(constraints(ocp)) #display(constraints(ocp))
+#println(constraints(ocp)) #display(constraints(ocp))
 sol = solve(ocp, grid_size=10, print_level=0, init=init)
 println(sol.objective)
 @testset verbose = true showtiming = true ":goddard :box_constraint" begin


### PR DESCRIPTION
…tipliers

See manual_test_goddard.jl, problem reformulated using all 5 types of constraints:

```
# state constraint
constraint!(ocp, :state, x->x[2], -Inf, 0.1, :state_con_vmax)
# control constraint
constraint!(ocp, :control, u->u, -Inf, 1, :control_con_umax)
# mixed constraint
constraint!(ocp, :mixed, (x,u)->x[3], 0.6, Inf, :mixed_con_mmin)
# state box
constraint!(ocp, :state, Index(1), 1, Inf, :state_box_rmin)
constraint!(ocp, :state, Index(2), 0, Inf, :state_box_vmin)
# control box
constraint!(ocp, :control, Index(1), 0, Inf, :control_box_umin)
```

Manual plot
```
# state constraints
ncx = sol.infos[:dim_state_constraints]
println("state contraints: ", ncx)
if ncx > 0
    PCX = Array{Plots.Plot, 1}(undef, ncx);
    for i in 1:ncx
        PCX[i] = plot(t -> sol.infos[:state_constraints](t)[i], t0, tf, label="state_constraint v <= 0.1", legend=:topleft)
        PCX[i] = plot!(twinx(), t -> sol.infos[:mult_state_constraints](t)[i], t0, tf, color=:red, label="multiplier", xticks=:none) #2nd scale
    end
    P1 = plot(PCX..., layout = (ncx,1));
else
    P1 = nothing
end
```

Result: plot of the 3 non-box constraints (NB. these are inequalities, and the labels have been hardcoded in the plot)
Plots use two y-axis scales, left for the constraints and right for the multipliers.
Signs and zero values of the multipliers seem OK.

![Untitled](https://user-images.githubusercontent.com/17044253/228807148-b06fa598-105a-4eac-8447-d7da075c7a82.png)
