### PR TITLE
fix for problems without box constraints

### DIFF
--- a/src/solution.jl
+++ b/src/solution.jl
@@ -92,10 +92,14 @@ function parse_ipopt_sol(ctd)
         X[i,:] = get_state_at_time_step(xu, i-1, ctd.dim_NLP_state, N)
         U[i,:] = get_control_at_time_step(xu, i-1, ctd.dim_NLP_state, N, ctd.control_dimension)
         # box multipliers (same layout as variables !)
-        mult_state_box_lower[i,:] = get_state_at_time_step(mult_L, i-1, ctd.dim_NLP_state, N)
-        mult_state_box_upper[i,:] = get_state_at_time_step(mult_U, i-1, ctd.dim_NLP_state, N)
-        mult_control_box_lower[i,:] = get_control_at_time_step(mult_L, i-1, ctd.dim_NLP_state, N, ctd.control_dimension)
-        mult_control_box_upper[i,:] = get_control_at_time_step(mult_U, i-1, ctd.dim_NLP_state, N, ctd.control_dimension)
+        if length(mult_L) > 0
+            mult_state_box_lower[i,:] = get_state_at_time_step(mult_L, i-1, ctd.dim_NLP_state, N)
+            mult_control_box_lower[i,:] = get_control_at_time_step(mult_L, i-1, ctd.dim_NLP_state, N, ctd.control_dimension)
+        end
+        if length(mult_U) > 0
+            mult_state_box_upper[i,:] = get_state_at_time_step(mult_U, i-1, ctd.dim_NLP_state, N)
+            mult_control_box_upper[i,:] = get_control_at_time_step(mult_U, i-1, ctd.dim_NLP_state, N, ctd.control_dimension)
+        end
     end
 
     # constraints, costate and constraints multipliers

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,7 +2,7 @@ using CTDirect
 using Test
 using CTBase
 using CTProblems
-using LinearAlgebra
+using LinearAlgebra # +++?
 
 include("test_utils.jl")
 
@@ -12,9 +12,7 @@ ocp = prob.model
 # test of optimal control problem from CTProblems
 @testset verbose = true showtiming = true "Direct" begin
     for name in (
-        #"simple_integrator_energy",
         "integrator",
-        #"integrator_constraints",
         "goddard",
         )
         @testset "$name" begin

--- a/test/test_integrator.jl
+++ b/test/test_integrator.jl
@@ -40,12 +40,12 @@ ocp = prob.model
         @test u_var == -l_var
     end
 
-    #=
+
     # Tests on the numerical solution
     @testset verbose = true showtiming = true "numerical solution" begin
-        #using LinearAlgebra
+
         sol = solve(ocp, grid_size=100, print_level=0) 
-        # check solution
+
         u_sol(t) = prob.solution.control(t)[1]
         u = t -> sol.control(t)[1]
         x_sol(t) = prob.solution.state(t)
@@ -53,16 +53,12 @@ ocp = prob.model
         T = sol.times
         dT = T[2:end]-T[1:end-1]
         N = length(T)
-        # test on the infty norm of the state
         @test distance_infty(x,x_sol,T) ≈ 0 atol = 0.01
-        #@test maximum([ sqrt(sum((x(T[i])-x_sol(T[i])).^2)) for i in 1:N]) ≈ 0 atol = 0.01
-        # test on the L_2 norm of the control
         @test distance_L2(u,u_sol,T) ≈ 0 atol=1e-1
-        # test on the objectif
         @test sol.objective ≈ prob.solution.objective atol=1e-2
-        # @test constraints_violation(sol) < 1e-6 # ceci n'existe pas dans la OptimalControlSolution pour le moment
+
     end
-    =#
+
 
 end
 


### PR DESCRIPTION
Fixed error for problems without box constraints (in this case NLPSolver_ipot return an empty vector for the multipliers instead of zeros -_-)
This was actually caught by the double integrator test, which I ... disabled before the release.
I think we need to keep simple tests in the automatic scripts, and use the more complicated ones as temporary manual tests.
Anyway, should work now.