### PR TITLE
api break from CTBase update

### DIFF
--- a/src/CTDirect.jl
+++ b/src/CTDirect.jl
@@ -15,7 +15,7 @@ const __grid_size_direct() = 100
 const __print_level_ipopt = CTBase.__print_level_ipopt
 const __mu_strategy_ipopt = CTBase.__mu_strategy_ipopt
 const __display = CTBase.__display
-const nlp_constraints = CTBase.nlp_constraints
+const nlp_constraints! = CTBase.nlp_constraints!
 const matrix2vec = CTBase.matrix2vec
 const __linear_solver() = "ma57"
 

--- a/src/problem.jl
+++ b/src/problem.jl
@@ -78,16 +78,16 @@ mutable struct DOCP
         N = docp.dim_NLP_steps
 
         # parse NLP constraints
-        docp.control_constraints, docp.state_constraints, docp.mixed_constraints, docp.boundary_conditions, docp.variable_constraints, docp.control_box, docp.state_box, docp.variable_box = nlp_constraints(ocp)
+        docp.control_constraints, docp.state_constraints, docp.mixed_constraints, docp.boundary_conditions, docp.variable_constraints, docp.control_box, docp.state_box, docp.variable_box = nlp_constraints!(ocp)
 
         # set dimensions
         # Mayer to Lagrange: additional state with Lagrange cost as dynamics and null initial condition
         if has_lagrange_cost(ocp)
             docp.dim_NLP_x = docp.ocp.state_dimension + 1  
-            docp.dim_NLP_constraints = N * (docp.dim_NLP_x + dim_path_constraints(ocp)) + dim_path_constraints(ocp) + dim_boundary_conditions(ocp) + dim_variable_constraints(ocp) + 1           
+            docp.dim_NLP_constraints = N * (docp.dim_NLP_x + dim_path_constraints(ocp)) + dim_path_constraints(ocp) + dim_boundary_constraints(ocp) + dim_variable_constraints(ocp) + 1           
         else
             docp.dim_NLP_x = docp.ocp.state_dimension  
-            docp.dim_NLP_constraints = N * (docp.dim_NLP_x + dim_path_constraints(ocp)) + dim_path_constraints(ocp) + dim_boundary_conditions(ocp) + dim_variable_constraints(ocp)
+            docp.dim_NLP_constraints = N * (docp.dim_NLP_x + dim_path_constraints(ocp)) + dim_path_constraints(ocp) + dim_boundary_constraints(ocp) + dim_variable_constraints(ocp)
         end
 
         docp.dim_NLP_u = ocp.control_dimension
@@ -177,10 +177,10 @@ function constraints_bounds(docp)
     end
     
     # boundary conditions
-    if dim_boundary_conditions(ocp) > 0
-        lb[index:index+dim_boundary_conditions(ocp)-1] = docp.boundary_conditions[1]
-        ub[index:index+dim_boundary_conditions(ocp)-1] = docp.boundary_conditions[3]
-        index = index + dim_boundary_conditions(ocp)
+    if dim_boundary_constraints(ocp) > 0
+        lb[index:index+dim_boundary_constraints(ocp)-1] = docp.boundary_conditions[1]
+        ub[index:index+dim_boundary_constraints(ocp)-1] = docp.boundary_conditions[3]
+        index = index + dim_boundary_constraints(ocp)
     end
 
     # variable constraints
@@ -397,10 +397,10 @@ function DOCP_constraints!(c, xu, docp)
     end
 
     # boundary conditions
-    if dim_boundary_conditions(ocp) > 0
+    if dim_boundary_constraints(ocp) > 0
         x0 = get_state_at_time_step(xu, docp, 0)
-        c[index:index+dim_boundary_conditions(ocp)-1] = docp.boundary_conditions[2](x0, xf, v)
-        index = index + dim_boundary_conditions(ocp)
+        c[index:index+dim_boundary_constraints(ocp)-1] = docp.boundary_conditions[2](x0, xf, v)
+        index = index + dim_boundary_constraints(ocp)
     end
 
     # variable constraints

--- a/src/solution.jl
+++ b/src/solution.jl
@@ -257,10 +257,10 @@ function parse_DOCP_solution(docp, solution, multipliers_constraints, multiplier
     end
 
     # boundary conditions and multipliers
-    if dim_boundary_conditions(ocp) > 0
-        sol_boundary_conditions = constraints[index:index+dim_boundary_conditions(ocp)-1]
-        mult_boundary_conditions = lambda[index:index+dim_boundary_conditions(ocp)-1]
-        index = index + dim_boundary_conditions(ocp)
+    if dim_boundary_constraints(ocp) > 0
+        sol_boundary_conditions = constraints[index:index+dim_boundary_constraints(ocp)-1]
+        mult_boundary_conditions = lambda[index:index+dim_boundary_constraints(ocp)-1]
+        index = index + dim_boundary_constraints(ocp)
     end
 
     # variable constraints and multipliers


### PR DESCRIPTION
@PierreMartinon check https://github.com/control-toolbox/CTDirect.jl/issues/121

New release needed

@ocots a few thoughts:
- API break so `CTBase.jl` release should have been `1.0.0`?
- I could (should...) have provided aliases / patches in `CTBase.jl` to ensure compat. with `CTDirect.jl`
- typical example showing that global test in our `OptimalControl.jl` / `CTxxxx.jl` hierarchy are in order; maybe could be included in `OptimalControl.jl` CI