### PR TITLE
0.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,6 @@
 [licence-img]: https://img.shields.io/badge/License-MIT-yellow.svg
 [licence-url]: https://github.com/control-toolbox/CTDirect.jl/blob/master/LICENSE
 
-[blue-img]: https://img.shields.io/badge/code%20style-blue-4495d1.svg
-[blue-url]: https://github.com/JuliaDiff/BlueStyle
-
 The CTDirect.jl package is part of the [control-toolbox ecosystem](https://github.com/control-toolbox).
 The control-toolbox ecosystem gathers Julia packages for mathematical control and applications. The root package is [OptimalControl.jl](https://github.com/control-toolbox/OptimalControl.jl) which aims to provide tools to modelise and solve optimal control problems with ordinary differential equations by direct and indirect methods.
 
@@ -35,7 +32,7 @@ The control-toolbox ecosystem gathers Julia packages for mathematical control an
 | **Name**          | **Badge**         |
 :-------------------|:------------------|
 | Documentation     | [![Documentation][doc-stable-img]][doc-stable-url] [![Documentation][doc-dev-img]][doc-dev-url]                   | 
-| Code Status       | [![Build Status][ci-img]][ci-url] [![Covering Status][co-img]][co-url] [![pkgeval][pkg-eval-img]][pkg-eval-url] [![Code Style: Blue][blue-img]][blue-url]  |
+| Code Status       | [![Build Status][ci-img]][ci-url] [![Covering Status][co-img]][co-url] [![pkgeval][pkg-eval-img]][pkg-eval-url]  |
 | Dependencies      | [![deps][deps-img]][deps-url] |
 | Licence           | [![License: MIT][licence-img]][licence-url]   |
 | Release           | [![Release][release-img]][release-url]        |


### PR DESCRIPTION
Main change for v0.13 is the discretization method option: in addition to the default trapeze method, one can chose the implicit midpoint or Gauss-Legendre collocation with 2 or 3 stages. Note that higher order methods typically increase the size of the discretized problem.

Current available options are:
disc_method = :trapeze [default] | :midpoint | :gauss_legendre_2 | :gauss_legendre_3