### PR TITLE
added default for adnlp AD backend

### DIFF
--- a/src/default.jl
+++ b/src/default.jl
@@ -27,6 +27,14 @@ __time_grid() = nothing
 """
 $(TYPEDSIGNATURES)
 
+Used to set the default backend for AD in ADNLPModels.
+The default value is `:optimized`.
+"""
+__adnlp_backend() = :optimized
+
+"""
+$(TYPEDSIGNATURES)
+
 Used to set the default tolerance.
 The default value is `1e-8`.
 """

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -92,6 +92,7 @@ function direct_solve(
     grid_size::Int = CTDirect.__grid_size(),
     time_grid = CTDirect.__time_grid(),
     disc_method = __disc_method(),
+    adnlp_backend = __adnlp_backend(),
     kwargs...,
 )
     method = getFullDescription(description, available_methods())
@@ -99,11 +100,12 @@ function direct_solve(
     # build discretized OCP, including initial guess
     docp, nlp = direct_transcription(
         ocp,
-        description,
+        description;
         init = init,
         grid_size = grid_size,
         time_grid = time_grid,
         disc_method = disc_method
+        adnlp_backend = adnlp_backend,
     )
 
     # solve DOCP

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -24,7 +24,8 @@ function direct_transcription(
     init = CTBase.__ocp_init(),
     grid_size = __grid_size(),
     time_grid = __time_grid(),
-    disc_method = __disc_method()
+    disc_method = __disc_method(),
+    adnlp_backend = __adnlp_backend()
 )
 
     # build DOCP
@@ -54,7 +55,7 @@ function direct_transcription(
         (c, x) -> DOCP_constraints!(c, x, docp),
         docp.con_l,
         docp.con_u,
-        backend = :optimized,
+        backend = adnlp_backend,
         #hessian_backend = ADNLPModels.EmptyADbackend
     )
 

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -104,7 +104,7 @@ function direct_solve(
         init = init,
         grid_size = grid_size,
         time_grid = time_grid,
-        disc_method = disc_method
+        disc_method = disc_method,
         adnlp_backend = adnlp_backend
     )
 

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -105,7 +105,7 @@ function direct_solve(
         grid_size = grid_size,
         time_grid = time_grid,
         disc_method = disc_method
-        adnlp_backend = adnlp_backend,
+        adnlp_backend = adnlp_backend
     )
 
     # solve DOCP


### PR DESCRIPTION
@PierreMartinon please review. still to be tested calling `solve` / `direct_transcription` with `adnlp_backend = :enzyme`, *e.g.* on Goddard, *etc.*