### PR TITLE
Added Euler methods (explict and implicit)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CTDirect"
 uuid = "790bbbee-bee9-49ee-8912-a9de031322d5"
 authors = ["Pierre Martinon <pierrecmartinon@gmail.com>", "Joseph Gergaud <joseph.gergaud@enseeiht.fr>", "Olivier Cots <olivier.cots@enseeiht.fr>"]
-version = "0.13.3"
+version = "0.13.4"
 
 [deps]
 ADNLPModels = "54578032-b7ea-4c30-94aa-7cbd1cce6c9a"

--- a/src/CTDirect.jl
+++ b/src/CTDirect.jl
@@ -15,9 +15,11 @@ const matrix2vec = CTBase.matrix2vec
 # includes
 include("default.jl")
 include("docp.jl")
+include("disc/common.jl")
+include("disc/euler.jl")
+include("disc/irk.jl")
 include("disc/midpoint.jl")
 include("disc/trapeze.jl")
-include("disc/irk.jl")
 include("solution.jl")
 include("solve.jl")
 

--- a/src/disc/common.jl
+++ b/src/disc/common.jl
@@ -1,0 +1,101 @@
+#= Common parts for the discretization =#
+
+
+"""
+$(TYPEDSIGNATURES)
+
+Retrieve optimization variables from the NLP variables.
+Convention: stored at the end, hence not dependent on the discretization method
+Scalar / Vector output
+"""
+function get_OCP_variable(xu, docp::DOCP{<: Discretization, <: ScalVect, <: ScalVect, ScalVariable})
+    return xu[docp.dim_NLP_variables]
+end
+function get_OCP_variable(xu, docp::DOCP{<: Discretization, <: ScalVect, <: ScalVect, VectVariable})
+    return @view xu[(docp.dim_NLP_variables - docp.dim_NLP_v + 1):docp.dim_NLP_variables]
+end
+
+
+"""
+$(TYPEDSIGNATURES)
+
+Retrieve state variables at given time step from the NLP variables.
+Convention: 1 <= i <= dim_NLP_steps+1
+Scalar / Vector output
+"""
+function get_OCP_state_at_time_step(xu, docp::DOCP{<: Discretization, ScalVariable, <: ScalVect, <: ScalVect}, i)
+    offset = (i-1) * docp.discretization._step_variables_block
+    return xu[offset+1]
+end
+function get_OCP_state_at_time_step(xu, docp::DOCP{<: Discretization, VectVariable, <: ScalVect, <: ScalVect}, i)
+    offset = (i-1) * docp.discretization._step_variables_block
+    return @view xu[(offset + 1):(offset + docp.dim_OCP_x)]
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Retrieve state variable for lagrange cost at given time step from the NLP variables.
+Convention: 1 <= i <= dim_NLP_steps+1
+"""
+function get_lagrange_state_at_time_step(xu, docp::DOCP{<: Discretization}, i)
+    offset = (i-1) * docp.discretization._step_variables_block
+    return xu[offset + docp.dim_NLP_x]
+end
+
+
+"""
+$(TYPEDSIGNATURES)
+
+Set initial guess for state variables at given time step
+Convention: 1 <= i <= dim_NLP_steps+1
+"""
+function set_state_at_time_step!(xu, x_init, docp::DOCP{<: Discretization}, i)
+    # initialize only actual state variables from OCP (not lagrange state)
+    if !isnothing(x_init)
+        offset = (i-1) * docp.discretization._step_variables_block
+        xu[(offset + 1):(offset + docp.dim_OCP_x)] .= x_init
+    end
+end
+"""
+$(TYPEDSIGNATURES)
+
+Set initial guess for control variables at given time step
+Convention: 1 <= i <= dim_NLP_steps
+"""
+function set_control_at_time_step!(xu, u_init, docp::DOCP{<: Discretization}, i)
+    if i <= docp.dim_NLP_steps && !isnothing(u_init)
+        offset = (i-1) * docp.discretization._step_variables_block + docp.dim_NLP_x
+        xu[(offset + 1):(offset + docp.dim_NLP_u)] .= u_init
+    end
+end
+
+
+"""
+$(TYPEDSIGNATURES)
+
+Set work array for all dynamics and lagrange cost evaluations
+"""
+function setWorkArray(docp::DOCP{<: Discretization}, xu, time_grid, v)
+    return nothing
+end
+
+
+"""
+$(TYPEDSIGNATURES)
+
+Build sparsity pattern for Jacobian of constraints
+"""
+function DOCP_Jacobian_pattern(docp::DOCP{D}) where (D <: Discretization)
+    error("DOCP_Jacobian_pattern not implemented for discretization ", D)
+end
+
+
+"""
+$(TYPEDSIGNATURES)
+
+Build sparsity pattern for Hessian of Lagrangian
+"""
+function DOCP_Hessian_pattern(docp::DOCP{D}) where (D <: Discretization)
+    error("DOCP_Hessian_pattern not implemented for discretization ", D)
+end

--- a/src/disc/euler.jl
+++ b/src/disc/euler.jl
@@ -1,0 +1,138 @@
+#= Functions for explicit and implicit euler discretization scheme
+Internal layout for NLP variables: 
+[X_1,U_1,K_1 .., X_N,U_N,K_N, X_N+1, V]
+with the convention 
+- Explicit Euler: u([t_i,t_i+1[) = U_i and u(tf) = U_N
+- Implicit Euler: u(]t_i,t_i+1]) = U_i and u(t0) = U_1
+=#
+
+struct Euler <: Discretization
+
+    info::String
+    _step_variables_block::Int
+    _state_stage_eqs_block::Int
+    _step_pathcons_block::Int
+    _explicit::Bool
+
+    # constructor
+    function Euler(dim_NLP_steps, dim_NLP_x, dim_NLP_u, dim_NLP_v, dim_u_cons, dim_x_cons, dim_xu_cons, dim_boundary_cons, dim_v_cons; explicit=true)
+
+        # aux variables
+        step_variables_block = dim_NLP_x + dim_NLP_u
+        state_stage_eqs_block = dim_NLP_x
+        step_pathcons_block = dim_u_cons + dim_x_cons + dim_xu_cons
+
+        # NLP variables size ([state, control]_1..N, final state, variable)
+        dim_NLP_variables = dim_NLP_steps * step_variables_block + dim_NLP_x + dim_NLP_v
+        
+        # NLP constraints size ([dynamics, path]_1..N, final path, boundary, variable)
+        dim_NLP_constraints = dim_NLP_steps * (state_stage_eqs_block + step_pathcons_block) + step_pathcons_block + dim_boundary_cons + dim_v_cons
+
+        if explicit 
+            info = "Euler (explicit), 1st order"
+        else
+            info = "Euler (implicit), 1st order"
+        end
+        disc = new(info, step_variables_block, state_stage_eqs_block, step_pathcons_block, explicit)
+
+        return disc, dim_NLP_variables, dim_NLP_constraints
+    end
+end
+
+
+"""
+$(TYPEDSIGNATURES)
+
+Retrieve control variables at given time step from the NLP variables.
+Convention: 1 <= i <= dim_NLP_steps(+1), with convention u(tf) = U_N
+Scalar / Vector output
+"""
+function get_OCP_control_at_time_step(xu, docp::DOCP{Euler, <: ScalVect, ScalVariable, <: ScalVect}, i)
+    if docp.discretization._explicit
+        # final time case
+        (i == docp.dim_NLP_steps + 1) && (i = docp.dim_NLP_steps)
+        offset = (i-1) * docp.discretization._step_variables_block + docp.dim_NLP_x
+    else
+        # initial time case
+        (i == 1) && (i = 2)
+        offset = (i-2) * docp.discretization._step_variables_block + docp.dim_NLP_x
+    end
+    return xu[offset+1]
+end
+function get_OCP_control_at_time_step(xu, docp::DOCP{Euler, <: ScalVect, VectVariable, <: ScalVect}, i)
+    if docp.discretization._explicit
+        # final time case
+        (i == docp.dim_NLP_steps + 1) && (i = docp.dim_NLP_steps)
+        offset = (i-1) * docp.discretization._step_variables_block + docp.dim_NLP_x
+    else 
+        # initial time case
+        (i == 1) && (i = 2)
+        offset = (i-2) * docp.discretization._step_variables_block + docp.dim_NLP_x
+    end
+    return @view xu[(offset + 1):(offset + docp.dim_NLP_u)]
+end
+
+
+"""
+$(TYPEDSIGNATURES)
+
+Set work array for all dynamics and lagrange cost evaluations
+"""
+function setWorkArray(docp::DOCP{Euler}, xu, time_grid, v)
+    work = similar(xu, docp.dim_NLP_x)
+    return work
+end
+
+
+"""
+$(TYPEDSIGNATURES)
+
+Set the constraints corresponding to the state equation
+Convention: 1 <= i <= dim_NLP_steps+1
+"""
+function setStepConstraints!(docp::DOCP{Euler}, c, xu, v, time_grid, i, work)
+    
+    # offset for previous steps
+    offset = (i-1)*(docp.discretization._state_stage_eqs_block + docp.discretization._step_pathcons_block)
+
+    # 0. variables
+    ti = time_grid[i]
+    xi = get_OCP_state_at_time_step(xu, docp, i)
+    ui = get_OCP_control_at_time_step(xu, docp, i)
+
+    # 1. state equation
+    if i <= docp.dim_NLP_steps
+        # more variables
+        tip1 = time_grid[i+1]
+        xip1 = get_OCP_state_at_time_step(xu, docp, i+1)
+        hi = tip1 - ti
+
+        # compute dynamics
+        if docp.discretization._explicit
+            # explicit Euler
+            docp.ocp.dynamics((@view work[1:docp.dim_OCP_x]), ti, xi, ui, v)
+            if docp.is_lagrange
+                docp.ocp.lagrange((@view work[docp.dim_NLP_x:docp.dim_NLP_x]),ti, xi, ui, v)
+            end
+        else
+            # implicit euler
+            uip1 = get_OCP_control_at_time_step(xu, docp, i+1)
+            docp.ocp.dynamics((@view work[1:docp.dim_OCP_x]), tip1, xip1, uip1, v)
+            if docp.is_lagrange
+                docp.ocp.lagrange((@view work[docp.dim_NLP_x:docp.dim_NLP_x]),tip1, xip1, uip1, v)
+            end
+        end
+       
+        # state equation: euler rule
+        @views @. c[offset+1:offset+docp.dim_OCP_x] = xip1 - (xi + hi * work[1:docp.dim_OCP_x])
+        if docp.is_lagrange
+        c[offset+docp.dim_NLP_x] = get_lagrange_state_at_time_step(xu, docp, i+1) - (get_lagrange_state_at_time_step(xu, docp, i) + hi * work[docp.dim_NLP_x])
+        end
+        offset += docp.dim_NLP_x
+
+    end
+   
+    # 2. path constraints
+    setPathConstraints!(docp, c, ti, xi, ui, v, offset)
+    
+end

--- a/src/disc/irk.jl
+++ b/src/disc/irk.jl
@@ -18,7 +18,7 @@ abstract type GenericIRK <: Discretization end
 $(TYPEDSIGNATURES)
 
 Implicit Midpoint discretization, formulated as a generic IRK (ie Gauss Legendre 1)
-NB. does not use the simplification xs = 0.5 * (xi + xip1) as in midpoint.jl
+For testing purpose only, use :midpoint instead (cf midpoint.jl) !
 """
 struct Gauss_Legendre_1 <: GenericIRK
 
@@ -37,7 +37,7 @@ struct Gauss_Legendre_1 <: GenericIRK
 
         step_variables_block, state_stage_eqs_block, step_pathcons_block, dim_NLP_variables, dim_NLP_constraints = IRK_dims(dim_NLP_steps, dim_NLP_x, dim_NLP_u, dim_NLP_v, dim_u_cons, dim_x_cons, dim_xu_cons, dim_boundary_cons, dim_v_cons, stage)
 
-        disc = new("Implicit Midpoint aka Gauss-Legendre collocation for s=1, 2nd order, symplectic, A-stable", stage, hcat(0.5), [1], [0.5], step_variables_block, state_stage_eqs_block, step_pathcons_block)
+        disc = new("[test only] Implicit Midpoint aka Gauss-Legendre collocation for s=1, 2nd order, symplectic, A-stable", stage, [0.5;;], [1], [0.5], step_variables_block, state_stage_eqs_block, step_pathcons_block)
 
         return disc, dim_NLP_variables, dim_NLP_constraints
     end
@@ -110,6 +110,101 @@ struct Gauss_Legendre_3 <: GenericIRK
         [0.5 - 0.1*sqrt(15), 0.5, 0.5 + 0.1*sqrt(15)],
         step_variables_block, state_stage_eqs_block, step_pathcons_block, control_type
         )
+
+        return disc, dim_NLP_variables, dim_NLP_constraints
+    end
+end
+
+
+"""
+$(TYPEDSIGNATURES)
+
+Explicit Euler discretization, formulated as a generic IRK
+For testing purpose only, use :euler instead (cf euler.jl) !
+"""
+struct Euler_explicit <: GenericIRK
+
+    info::String
+    stage::Int
+    butcher_a::Matrix{Float64}
+    butcher_b::Vector{Float64}
+    butcher_c::Vector{Float64}
+    _step_variables_block::Int
+    _state_stage_eqs_block::Int
+    _step_pathcons_block::Int
+
+    function Euler_explicit(dim_NLP_steps, dim_NLP_x, dim_NLP_u, dim_NLP_v, dim_u_cons, dim_x_cons, dim_xu_cons, dim_boundary_cons, dim_v_cons)
+        
+        stage = 1
+
+        step_variables_block, state_stage_eqs_block, step_pathcons_block, dim_NLP_variables, dim_NLP_constraints =  IRK_dims(dim_NLP_steps, dim_NLP_x, dim_NLP_u, dim_NLP_v, dim_u_cons, dim_x_cons, dim_xu_cons, dim_boundary_cons, dim_v_cons, stage)
+
+        disc = new("[test only] Explicit Euler, 1st order",stage, [0.;;], [1.], [0.],
+        step_variables_block, state_stage_eqs_block, step_pathcons_block)
+
+        return disc, dim_NLP_variables, dim_NLP_constraints
+    end
+end
+
+
+"""
+$(TYPEDSIGNATURES)
+
+Implicit Euler discretization, formulated as a generic IRK
+For testing purpose only, use :euler_implicit instead (cf euler.jl) !
+"""
+struct Euler_implicit <: GenericIRK
+
+    info::String
+    stage::Int
+    butcher_a::Matrix{Float64}
+    butcher_b::Vector{Float64}
+    butcher_c::Vector{Float64}
+    _step_variables_block::Int
+    _state_stage_eqs_block::Int
+    _step_pathcons_block::Int
+
+    function Euler_implicit(dim_NLP_steps, dim_NLP_x, dim_NLP_u, dim_NLP_v, dim_u_cons, dim_x_cons, dim_xu_cons, dim_boundary_cons, dim_v_cons)
+        
+        stage = 1
+
+        step_variables_block, state_stage_eqs_block, step_pathcons_block, dim_NLP_variables, dim_NLP_constraints =  IRK_dims(dim_NLP_steps, dim_NLP_x, dim_NLP_u, dim_NLP_v, dim_u_cons, dim_x_cons, dim_xu_cons, dim_boundary_cons, dim_v_cons, stage)
+
+        disc = new("[test only] Implicit Euler, 1st order",stage, [1.;;], [1.], [1.],
+        step_variables_block, state_stage_eqs_block, step_pathcons_block)
+
+        return disc, dim_NLP_variables, dim_NLP_constraints
+    end
+end
+
+
+"""
+$(TYPEDSIGNATURES)
+
+Implicit Trapeze (Crank-Nicolson) discretization, formulated as a generic IRK
+For testing purpose only, use :trapeze instead (cf trapeze.jl) !
+"""
+struct Trapeze_implicit <: GenericIRK
+
+    info::String
+    stage::Int
+    butcher_a::Matrix{Float64}
+    butcher_b::Vector{Float64}
+    butcher_c::Vector{Float64}
+    _step_variables_block::Int
+    _state_stage_eqs_block::Int
+    _step_pathcons_block::Int
+    _control_type::Symbol
+
+    function Trapeze_implicit(dim_NLP_steps, dim_NLP_x, dim_NLP_u, dim_NLP_v, dim_u_cons, dim_x_cons, dim_xu_cons, dim_boundary_cons, dim_v_cons, control_type)
+        
+        stage = 2
+
+        step_variables_block, state_stage_eqs_block, step_pathcons_block, dim_NLP_variables, dim_NLP_constraints =  IRK_dims(dim_NLP_steps, dim_NLP_x, dim_NLP_u, dim_NLP_v, dim_u_cons, dim_x_cons, dim_xu_cons, dim_boundary_cons, dim_v_cons, stage)
+
+        disc = new("[test only] Implicit Trapeze aka Crank-Nicolson, 2nd order, A-stable",stage, 
+        [0 0; 0.5 0.5], [0.5, 0.5], [0.5, 0.5],
+        step_variables_block, state_stage_eqs_block, step_pathcons_block, control_type)
 
         return disc, dim_NLP_variables, dim_NLP_constraints
     end

--- a/src/disc/midpoint.jl
+++ b/src/disc/midpoint.jl
@@ -3,7 +3,8 @@ Internal layout for NLP variables:
 [X_1,U_1,K_1 .., X_N,U_N,K_N, X_N+1, V]
 with the convention u([t_i,t_i+1[) = U_i and u(tf) = U_N
 NB. stage variables K_i can be removed via the simplification x_s = (x_i + x_i+1) / 2
-however this seems to give worse performance...
+hence k_i = f(x_i + x_i+1)/2), however this seems to give worse performance...
++++ to be rechecked !
 =#
 
 struct Midpoint <: Discretization
@@ -21,7 +22,7 @@ struct Midpoint <: Discretization
         state_stage_eqs_block = dim_NLP_x * 2
         step_pathcons_block = dim_u_cons + dim_x_cons + dim_xu_cons
 
-        # NLP variables size ([state, control]_1..N, final state, variable)
+        # NLP variables size ([state, control, stage]_1..N, final state, variable)
         dim_NLP_variables = dim_NLP_steps * step_variables_block + dim_NLP_x + dim_NLP_v
         
         # NLP constraints size ([dynamics, path]_1..N, final path, boundary, variable)
@@ -49,6 +50,8 @@ function get_OCP_state_at_time_step(xu, docp::DOCP{Midpoint, VectVariable, <: Sc
     offset = (i-1) * docp.discretization._step_variables_block
     return @view xu[(offset + 1):(offset + docp.dim_OCP_x)]
 end
+
+
 """
 $(TYPEDSIGNATURES)
 
@@ -59,6 +62,8 @@ function get_lagrange_state_at_time_step(xu, docp::DOCP{Midpoint}, i)
     offset = (i-1) * docp.discretization._step_variables_block
     return xu[offset + docp.dim_NLP_x]
 end
+
+
 """
 $(TYPEDSIGNATURES)
 
@@ -79,6 +84,7 @@ function get_OCP_control_at_time_step(xu, docp::DOCP{Midpoint, <: ScalVect, Vect
     return @view xu[(offset + 1):(offset + docp.dim_NLP_u)]
 end
 
+
 """
 $(TYPEDSIGNATURES)
 
@@ -90,7 +96,6 @@ function get_stagevars_at_time_step(xu, docp::DOCP{Midpoint}, i, j)
     offset = (i-1) * docp.discretization._step_variables_block + docp.dim_NLP_x + docp.dim_NLP_u + (j-1)*docp.dim_NLP_x
     return @view xu[(offset + 1):(offset + docp.dim_NLP_x)]
 end
-
 
 """
 $(TYPEDSIGNATURES)
@@ -105,6 +110,7 @@ function set_state_at_time_step!(xu, x_init, docp::DOCP{Midpoint}, i)
         xu[(offset + 1):(offset + docp.dim_OCP_x)] .= x_init
     end
 end
+
 """
 $(TYPEDSIGNATURES)
 
@@ -130,7 +136,6 @@ function setWorkArray(docp::DOCP{Midpoint}, xu, time_grid, v)
     return work
 
 end
-
 
 """
 $(TYPEDSIGNATURES)

--- a/src/disc/trapeze.jl
+++ b/src/disc/trapeze.jl
@@ -3,7 +3,7 @@ Internal layout for NLP variables:
 [X_1,U_1, .., X_N+1,U_N+1, V]
 =#
 
-# NB. could be defined as a generic IRK
+# NB. could also be defined as a generic IRK for testing
 struct Trapeze <: Discretization
 
     info::String
@@ -29,14 +29,6 @@ struct Trapeze <: Discretization
 
         return disc, dim_NLP_variables, dim_NLP_constraints
     end
-end
-
-# not only for Trapeze, but may be redefined if needed
-function get_OCP_variable(xu, docp::DOCP{<: Discretization, <: ScalVect, <: ScalVect, ScalVariable})
-    return xu[docp.dim_NLP_variables]
-end
-function get_OCP_variable(xu, docp::DOCP{<: Discretization, <: ScalVect, <: ScalVect, VectVariable})
-    return @view xu[(docp.dim_NLP_variables - docp.dim_NLP_v + 1):docp.dim_NLP_variables]
 end
 
 

--- a/src/docp.jl
+++ b/src/docp.jl
@@ -186,14 +186,24 @@ struct DOCP{T <: Discretization, X <: ScalVect, U <: ScalVect, V <: ScalVect, G 
             discretization, dim_NLP_variables, dim_NLP_constraints = CTDirect.Trapeze(dim_NLP_steps, dim_NLP_x, dim_NLP_u, dim_NLP_v, dim_u_cons, dim_x_cons, dim_xu_cons, dim_boundary_cons, dim_v_cons)
         elseif disc_method == :midpoint
             discretization, dim_NLP_variables, dim_NLP_constraints = CTDirect.Midpoint(dim_NLP_steps, dim_NLP_x, dim_NLP_u, dim_NLP_v, dim_u_cons, dim_x_cons, dim_xu_cons, dim_boundary_cons, dim_v_cons)
-        elseif disc_method == :gauss_legendre_1
+        elseif disc_method == :euler
+            discretization, dim_NLP_variables, dim_NLP_constraints = CTDirect.Euler(dim_NLP_steps, dim_NLP_x, dim_NLP_u, dim_NLP_v, dim_u_cons, dim_x_cons, dim_xu_cons, dim_boundary_cons, dim_v_cons)
+        elseif disc_method == :euler_implicit
+            discretization, dim_NLP_variables, dim_NLP_constraints = CTDirect.Euler(dim_NLP_steps, dim_NLP_x, dim_NLP_u, dim_NLP_v, dim_u_cons, dim_x_cons, dim_xu_cons, dim_boundary_cons, dim_v_cons; explicit=false)
+        elseif disc_method == :midpoint_irk
                 discretization, dim_NLP_variables, dim_NLP_constraints = CTDirect.Gauss_Legendre_1(dim_NLP_steps, dim_NLP_x, dim_NLP_u, dim_NLP_v, dim_u_cons, dim_x_cons, dim_xu_cons, dim_boundary_cons, dim_v_cons)
         elseif disc_method == :gauss_legendre_2
                 discretization, dim_NLP_variables, dim_NLP_constraints = CTDirect.Gauss_Legendre_2(dim_NLP_steps, dim_NLP_x, dim_NLP_u, dim_NLP_v, dim_u_cons, dim_x_cons, dim_xu_cons, dim_boundary_cons, dim_v_cons, control_type)
         elseif disc_method == :gauss_legendre_3
-                discretization, dim_NLP_variables, dim_NLP_constraints = CTDirect.Gauss_Legendre_3(dim_NLP_steps, dim_NLP_x, dim_NLP_u, dim_NLP_v, dim_u_cons, dim_x_cons, dim_xu_cons, dim_boundary_cons, dim_v_cons, control_type)                                 
+                discretization, dim_NLP_variables, dim_NLP_constraints = CTDirect.Gauss_Legendre_3(dim_NLP_steps, dim_NLP_x, dim_NLP_u, dim_NLP_v, dim_u_cons, dim_x_cons, dim_xu_cons, dim_boundary_cons, dim_v_cons, control_type)
+        elseif disc_method == :euler_irk
+                discretization, dim_NLP_variables, dim_NLP_constraints = CTDirect.Euler_explicit(dim_NLP_steps, dim_NLP_x, dim_NLP_u, dim_NLP_v, dim_u_cons, dim_x_cons, dim_xu_cons, dim_boundary_cons, dim_v_cons)
+        elseif disc_method == :euler_implicit_irk
+                discretization, dim_NLP_variables, dim_NLP_constraints = CTDirect.Euler_implicit(dim_NLP_steps, dim_NLP_x, dim_NLP_u, dim_NLP_v, dim_u_cons, dim_x_cons, dim_xu_cons, dim_boundary_cons, dim_v_cons)
+        elseif disc_method == :trapeze_irk
+                discretization, dim_NLP_variables, dim_NLP_constraints = CTDirect.Trapeze_implicit(dim_NLP_steps, dim_NLP_x, dim_NLP_u, dim_NLP_v, dim_u_cons, dim_x_cons, dim_xu_cons, dim_boundary_cons, dim_v_cons, control_type)           
         else           
-            error("Unknown discretization method: ", disc_method, "\nValid options are disc_method={:trapeze, :midpoint, :gauss_legendre_1, :gauss_legendre_2, :gauss_legendre_3}\n", typeof(disc_method))
+            error("Unknown discretization method: ", disc_method, "\nValid options are disc_method={:euler, :euler_implicit, :trapeze, :trapeze_irk, :midpoint, :gauss_legendre_2, :gauss_legendre_3, (:euler_irk, :euler_implicit_irk, :midpoint_irk, :trapeze_irk)}\n", typeof(disc_method))
         end
 
         # add initial condition for lagrange state

--- a/src/docp.jl
+++ b/src/docp.jl
@@ -190,7 +190,7 @@ struct DOCP{T <: Discretization, X <: ScalVect, U <: ScalVect, V <: ScalVect, G 
             discretization, dim_NLP_variables, dim_NLP_constraints = CTDirect.Euler(dim_NLP_steps, dim_NLP_x, dim_NLP_u, dim_NLP_v, dim_u_cons, dim_x_cons, dim_xu_cons, dim_boundary_cons, dim_v_cons)
         elseif disc_method == :euler_implicit
             discretization, dim_NLP_variables, dim_NLP_constraints = CTDirect.Euler(dim_NLP_steps, dim_NLP_x, dim_NLP_u, dim_NLP_v, dim_u_cons, dim_x_cons, dim_xu_cons, dim_boundary_cons, dim_v_cons; explicit=false)
-        elseif disc_method == :midpoint_irk
+        elseif disc_method == :gauss_legendre_1
                 discretization, dim_NLP_variables, dim_NLP_constraints = CTDirect.Gauss_Legendre_1(dim_NLP_steps, dim_NLP_x, dim_NLP_u, dim_NLP_v, dim_u_cons, dim_x_cons, dim_xu_cons, dim_boundary_cons, dim_v_cons)
         elseif disc_method == :gauss_legendre_2
                 discretization, dim_NLP_variables, dim_NLP_constraints = CTDirect.Gauss_Legendre_2(dim_NLP_steps, dim_NLP_x, dim_NLP_u, dim_NLP_v, dim_u_cons, dim_x_cons, dim_xu_cons, dim_boundary_cons, dim_v_cons, control_type)
@@ -203,7 +203,7 @@ struct DOCP{T <: Discretization, X <: ScalVect, U <: ScalVect, V <: ScalVect, G 
         elseif disc_method == :trapeze_irk
                 discretization, dim_NLP_variables, dim_NLP_constraints = CTDirect.Trapeze_implicit(dim_NLP_steps, dim_NLP_x, dim_NLP_u, dim_NLP_v, dim_u_cons, dim_x_cons, dim_xu_cons, dim_boundary_cons, dim_v_cons, control_type)           
         else           
-            error("Unknown discretization method: ", disc_method, "\nValid options are disc_method={:euler, :euler_implicit, :trapeze, :trapeze_irk, :midpoint, :gauss_legendre_2, :gauss_legendre_3, (:euler_irk, :euler_implicit_irk, :midpoint_irk, :trapeze_irk)}\n", typeof(disc_method))
+            error("Unknown discretization method: ", disc_method, "\nValid options are disc_method={:euler, :euler_implicit, :trapeze, :trapeze_irk, :midpoint, :gauss_legendre_2, :gauss_legendre_3, (:euler_irk, :euler_implicit_irk, :gauss_legendre_1, :trapeze_irk)}\n", typeof(disc_method))
         end
 
         # add initial condition for lagrange state

--- a/test/benchmark.jl
+++ b/test/benchmark.jl
@@ -8,6 +8,7 @@ using NLPModelsIpopt
 using MKL # Replace OpenBLAS with Intel MKL +++ should be an option
 
 using BenchmarkTools
+using Plots
 using Printf
 using Profile
 using PProf

--- a/test/suite/test_discretization.jl
+++ b/test/suite/test_discretization.jl
@@ -58,18 +58,20 @@ end
     @test sol.time_grid ≈ time_grid
 end
 
-# implicit midpoint scheme
+# discretization methods
 if !isdefined(Main, :goddard_all)
     include("../problems/goddard.jl")
 end
 
-@testset verbose = true showtiming = true ":simple_integrator :trapeze :midpoint :gl2" begin
+@testset verbose = true showtiming = true ":simple_integrator :disc_method" begin
     prob = simple_integrator()
     sol = direct_solve(prob.ocp, display = false, disc_method = :trapeze)
     @test sol.objective ≈ prob.obj rtol = 1e-2
     sol = direct_solve(prob.ocp, display = false, disc_method = :midpoint)
     @test sol.objective ≈ prob.obj rtol = 1e-2
-    sol = direct_solve(prob.ocp, display = false, disc_method = :gauss_legendre_1)
+    sol = direct_solve(prob.ocp, display = false, disc_method = :euler)
+    @test sol.objective ≈ prob.obj rtol = 1e-2
+    sol = direct_solve(prob.ocp, display = false, disc_method = :euler_implicit)
     @test sol.objective ≈ prob.obj rtol = 1e-2
     sol = direct_solve(prob.ocp, display = false, disc_method = :gauss_legendre_2)
     @test sol.objective ≈ prob.obj rtol = 1e-2
@@ -77,13 +79,15 @@ end
     @test sol.objective ≈ prob.obj rtol = 1e-2 
 end
 
-@testset verbose = true showtiming = true ":double_integrator :trapeze :midpoint :gl2" begin
+@testset verbose = true showtiming = true ":double_integrator :disc_method" begin
     prob = double_integrator_freet0tf()
     sol = direct_solve(prob.ocp, display = false, disc_method = :trapeze)
     @test sol.objective ≈ prob.obj rtol = 1e-2
     sol = direct_solve(prob.ocp, display = false, disc_method = :midpoint)
     @test sol.objective ≈ prob.obj rtol = 1e-2
-    sol = direct_solve(prob.ocp, display = false, disc_method = :gauss_legendre_1)
+    sol = direct_solve(prob.ocp, display = false, disc_method = :euler)
+    @test sol.objective ≈ prob.obj rtol = 1e-2
+    sol = direct_solve(prob.ocp, display = false, disc_method = :euler_implicit)
     @test sol.objective ≈ prob.obj rtol = 1e-2
     sol = direct_solve(prob.ocp, display = false, disc_method = :gauss_legendre_2)
     @test sol.objective ≈ prob.obj rtol = 1e-2
@@ -91,13 +95,15 @@ end
     @test sol.objective ≈ prob.obj rtol = 1e-2  
 end
 
-@testset verbose = true showtiming = true ":goddard :trapeze :midpoint :gl2" begin
+@testset verbose = true showtiming = true ":goddard :disc_method" begin
     prob = goddard_all()
     sol = direct_solve(prob.ocp, display = false, disc_method = :trapeze)
     @test sol.objective ≈ prob.obj rtol = 1e-2
     sol = direct_solve(prob.ocp, display = false, disc_method = :midpoint)
     @test sol.objective ≈ prob.obj rtol = 1e-2
-    sol = direct_solve(prob.ocp, display = false, disc_method = :gauss_legendre_1)
+    sol = direct_solve(prob.ocp, display = false, disc_method = :euler)
+    @test sol.objective ≈ prob.obj rtol = 1e-2
+    sol = direct_solve(prob.ocp, display = false, disc_method = :euler_implicit)
     @test sol.objective ≈ prob.obj rtol = 1e-2
     sol = direct_solve(prob.ocp, display = false, disc_method = :gauss_legendre_2)
     @test sol.objective ≈ prob.obj rtol = 1e-2


### PR DESCRIPTION
`sol = direct_solve(ocp; disc_method=:euler)`
`sol = direct_solve(ocp; disc_method=:euler_implicit)`

Also added an IRK version (with full Butcher table) for these, which is less efficient, as expected. Likewise, IRK formulations for the implicit trapeze and midpoint methods is slower than their manual implementation, as the latter use some specific simplifications for each method.
