### PR TITLE
0.17.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,6 +15,7 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 ADNLPModels = "54578032-b7ea-4c30-94aa-7cbd1cce6c9a"
 ExaModels = "1037b233-b668-4ce9-9b63-f9f681f55dd2"
 MadNLP = "2621e9c9-9eb4-46b1-8089-e8c72242dfb6"
+MadNLPMumps = "3b83494e-c0a4-4895-918b-9157a7a085a1"
 NLPModelsIpopt = "f4238b75-b362-5c4c-b852-0801c9a21d71"
 NLPModelsKnitro = "bec4dd0d-7755-52d5-9a02-22f0ffc7efcb"
 
@@ -23,7 +24,7 @@ CTDirectExtADNLP = ["ADNLPModels"]
 CTDirectExtExa = ["ExaModels"]
 CTDirectExtIpopt = ["NLPModelsIpopt"]
 CTDirectExtKnitro = ["NLPModelsKnitro"]
-CTDirectExtMadNLP = ["MadNLP"]
+CTDirectExtMadNLP = ["MadNLP", "MadNLPMumps"]
 
 [compat]
 ADNLPModels = "0.8"
@@ -36,6 +37,7 @@ ExaModels = "0.9"
 HSL = "0.5"
 MKL = "0.9"
 MadNLP = "0.8"
+MadNLPMumps = "0.5"
 MadNLPGPU = "0.7"
 NLPModelsIpopt = "0.10"
 NLPModelsKnitro = "0.9"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CTDirect"
 uuid = "790bbbee-bee9-49ee-8912-a9de031322d5"
 authors = ["Pierre Martinon <pierrecmartinon@gmail.com>"]
-version = "0.16.3"
+version = "0.17.0"
 
 [deps]
 CTBase = "54762871-cc72-4466-b8e8-f6c8b58076cd"

--- a/ext/CTDirectExtADNLP.jl
+++ b/ext/CTDirectExtADNLP.jl
@@ -26,6 +26,8 @@ function CTDirect.build_nlp!(
     kwargs...,
 )
 
+    # +++ minimize[=true], set to false if flags max and not max_to_min
+
     # redeclare objective and constraints functions
     f = x -> CTDirect.DOCP_objective(x, docp)
     c! = (c, x) -> CTDirect.DOCP_constraints!(c, x, docp)

--- a/ext/CTDirectExtMadNLP.jl
+++ b/ext/CTDirectExtMadNLP.jl
@@ -5,6 +5,7 @@ using CTDirect
 using DocStringExtensions
 
 using MadNLP
+using MadNLPMumps
 using HSL
 using MKL
 
@@ -19,6 +20,7 @@ function CTDirect.solve_docp(
     display::Bool=CTDirect.__display(),
     max_iter::Integer=CTDirect.__max_iterations(),
     tol::Real=CTDirect.__tolerance(),
+    linear_solver=CTDirect.__madnlp_linear_solver(),
     kwargs...,
 )
 
@@ -28,9 +30,15 @@ function CTDirect.solve_docp(
     # retrieve NLP
     nlp = CTDirect.model(docp)
 
+    # set linear solver
+    if linear_solver == "umfpack"
+        linear_solver = MadNLP.UmfpackSolver
+    elseif linear_solver == "mumps"
+        linear_solver = MadNLPMumps.MumpsSolver
+    end
+
     # preallocate solver (NB. need to pass printlevel here)
-    solver = MadNLPSolver(
-        nlp; print_level=print_level, tol=tol, max_iter=max_iter, kwargs...
+    solver = MadNLPSolver(nlp; print_level=print_level, tol=tol, max_iter=max_iter, linear_solver=linear_solver, kwargs...
     )
 
     # solve discretized problem with NLP solver

--- a/src/default.jl
+++ b/src/default.jl
@@ -91,12 +91,12 @@ Default value for Ipopt linear solver: `mumps`
 """
 __ipopt_linear_solver() = "mumps"
 
-#="""
+"""
 $(TYPEDSIGNATURES)
 
-Default value for MadNLP linear solver: `umfpack`
+Default value for MadNLP linear solver: `mumps`
 """
-__madnlp_linear_solver() = "umfpack"=#
+__madnlp_linear_solver() = "mumps"
 
 """
 $(TYPEDSIGNATURES)

--- a/src/default.jl
+++ b/src/default.jl
@@ -3,9 +3,9 @@
 """
 $(TYPEDSIGNATURES)
 
-Default discretization method: `trapeze`.
+Default discretization method: `midpoint`.
 """
-__disc_method() = :trapeze
+__disc_method() = :midpoint
 
 """
 $(TYPEDSIGNATURES)
@@ -37,15 +37,24 @@ __time_grid() = nothing
 
 """
 $(TYPEDSIGNATURES)
+
 Default backend for ADNLPModels: `:optimized`
 """
 __adnlp_backend() = :optimized
 
 """
 $(TYPEDSIGNATURES)
+
 Default backend for ExaModels: `nothing`
 """
 __exa_backend() = nothing
+
+"""
+$(TYPEDSIGNATURES)
+
+Reformulate Lagrange cost as Mayer cost: false
+"""
+__lagrange_to_mayer() = false
 
 """
 $(TYPEDSIGNATURES)

--- a/src/docp.jl
+++ b/src/docp.jl
@@ -457,6 +457,8 @@ function DOCP_objective(xu, docp::DOCP)
     obj = obj_mayer + obj_lagrange
 
     # maximization problem
+    # +++ add a max_to_min flag in DOCP
+    # option minimize[=true] for adnlpmodels
     if docp.flags.max
         obj = -obj
     end

--- a/src/docp.jl
+++ b/src/docp.jl
@@ -188,7 +188,7 @@ mutable struct DOCP{D<:Discretization,O<:CTModels.Model}
         grid_size=__grid_size(),
         time_grid=__time_grid(),
         disc_method=__disc_method(),
-        lagrange_to_mayer=true,
+        lagrange_to_mayer=__lagrange_to_mayer(),
     )
 
         # boolean flags

--- a/src/solution.jl
+++ b/src/solution.jl
@@ -33,6 +33,7 @@ function build_OCP_solution(docp, docp_solution; nlp_model=ADNLPBackend())
     )
 
     # objective from solution
+    # +++ add a max_to_min flag in DOCP
     if docp.flags.max
         objective = -docp_solution.objective
     else
@@ -131,13 +132,8 @@ function build_OCP_solution(
         docp_solution=docp_solution,
     )
 
-    # recompute objective (NB lagrange without conversion not supported)
-    if docp.flags.lagrange_to_mayer
-        objective = DOCP_objective(solution, docp)
-    else
-        println("Warning: cannot recompute objective (lagrange to mayer disabled)")
-        objective = 0.0
-    end
+    # recompute objective
+    objective = DOCP_objective(solution, docp)
     if docp.flags.max
         objective = -objective
     end

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -149,7 +149,7 @@ function solve(
     init=__ocp_init(),
     adnlp_backend=__adnlp_backend(),
     exa_backend=__exa_backend(),
-    lagrange_to_mayer=true,
+    lagrange_to_mayer=__lagrange_to_mayer(),
     kwargs...,
 )
 
@@ -248,7 +248,7 @@ function direct_transcription(
     disc_method=__disc_method(),
     time_grid=__time_grid(),
     init=__ocp_init(),
-    lagrange_to_mayer=true,
+    lagrange_to_mayer=__lagrange_to_mayer(),
     kwargs...,
 )
     nlp_solver, nlp_model = parse_description(description)

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -48,7 +48,7 @@ struct ExaBackend <: AbstractNLPModelBackend end
 const WEAKDEPS = Dict{Type,Any}(
     # NLP solver
     IpoptBackend => [:NLPModelsIpopt],
-    MadNLPBackend => [:MadNLP],
+    MadNLPBackend => [:MadNLP, :MadNLPMumps],
     KnitroBackend => [:NLPModelsKnitro],
     # NLP modeller
     ADNLPBackend => [:ADNLPModels],

--- a/test/suite/test_exa.jl
+++ b/test/suite/test_exa.jl
@@ -92,7 +92,13 @@ function test_exa(exa_backend, display)
 
     @testset verbose = true showtiming = true ":examodel :cpu :transcription :grid_size" begin
         prob = beam2()
-        docp = direct_transcription(prob.ocp, :madnlp, :exa; display=display, grid_size=100)
+        docp = direct_transcription(
+            prob.ocp, 
+            :madnlp, 
+            :exa; 
+            display=display,
+            disc_method=:trapeze, 
+            grid_size=100)
         @test docp.dim_NLP_variables == 303
     end
 end


### PR DESCRIPTION
Changes in default settings:
- Midpoint is now the default discretization (previously Trapeze)
- Lagrange to Mayer cost reformulation is now disabled by default (already the case for ExaModels, now for ADNLPModels as well)
- Mumps is now the default linear solver for MadNLP (previously umfpack, cf https://github.com/control-toolbox/CTDirect.jl/issues/485)
