### PR TITLE
Update docstrings

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CTDirect"
 uuid = "790bbbee-bee9-49ee-8912-a9de031322d5"
 authors = ["Pierre Martinon <pierrecmartinon@gmail.com>"]
-version = "0.17.0"
+version = "0.17.1"
 
 [deps]
 CTBase = "54762871-cc72-4466-b8e8-f6c8b58076cd"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -38,6 +38,7 @@ API_PAGES = [
     "solution.md",
     "solve.md",
     "trapeze.md",
+    "utils.md",
 ]
 
 makedocs(;

--- a/docs/src/utils.md
+++ b/docs/src/utils.md
@@ -1,0 +1,17 @@
+# Utils
+
+## Index
+
+```@index
+Pages   = ["utils.md"]
+Modules = [CTDirect]
+Order = [:module, :constant, :type, :function, :macro]
+```
+
+## Documentation
+
+```@autodocs
+Pages = ["utils.jl"]
+Modules = [CTDirect]
+Order = [:module, :constant, :type, :function, :macro]
+```

--- a/src/CTDirect.jl
+++ b/src/CTDirect.jl
@@ -1,7 +1,7 @@
 module CTDirect
 
+using CTBase
 using CTModels: CTModels
-
 using DocStringExtensions
 using SparseArrays
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,3 +1,39 @@
+"""
+$(TYPEDSIGNATURES)
+
+Return the version number of the current package as a string.
+
+# Returns
+
+- `version::String`: The version of the current module.
+
+# Example
+
+```julia-repl
+julia> version()
+"1.2.3"
+```
+"""
 version() = string(pkgversion(@__MODULE__))
 
+"""
+$(TYPEDSIGNATURES)
+
+Check whether a package with the given name is currently loaded.
+
+# Arguments
+
+- `pkg::String`: The name of the package to check.
+
+# Returns
+
+- `is_loaded::Bool`: `true` if the package is loaded, `false` otherwise.
+
+# Example
+
+```julia-repl
+julia> package_loaded("LinearAlgebra")
+true
+```
+"""
 package_loaded(pkg::String) = any(k -> k.name == pkg, keys(Base.loaded_modules))


### PR DESCRIPTION
@PierreMartinon I have reviewed quickly some docstrings. The important thing is that we need docstrings for `ocp_model` and `nlp_model` to make the documentation of OptimalControl. I don't remember why there is a problem if not. Anyway, I have added docstrings. Is it ok for you?